### PR TITLE
fix(style-eval): fall back to reference targets for qualitative profiles

### DIFF
--- a/docs/fix-notes/2026-09-02-style-blind-review-metric-fallback.md
+++ b/docs/fix-notes/2026-09-02-style-blind-review-metric-fallback.md
@@ -1,0 +1,31 @@
+# Style blind-review metric fallback fix
+
+## Module Change Packet
+
+```yaml
+module_change_packet:
+  objective: "内置定性 Style Profile 缺少数值目标时，blind-review 仍可用 reference 计算标点与感官匹配，避免候选被必然压成零分"
+  primary_module: "literary_engineering_studio_engine.literary.style.evaluator"
+  public_entry: "evaluate_style(StyleEvalOptions)"
+  variation_point: "punctuation/sensory profile target selection"
+  inputs: ["style_metrics.json", "reference text", "candidate text"]
+  outputs: ["style_eval_current.json 分项评分", "style_eval_current.md"]
+  invariants: ["不修改候选或评分文件", "不 reinterpret failed gate", "已有显式 Profile 数值目标优先于 reference fallback"]
+  allowed_dependencies: ["literary/style/compiler.analyze_style"]
+  forbidden_dependencies: ["model provider abstraction", "API-key storage", "direct HTTP LLM client"]
+  tests: ["tests.test_style_evaluation_loop metric fallback regression", "prompt registry validation", "architecture audit"]
+  rollback_unit: "one Git commit"
+  documentation: ["docs/fix-notes/2026-09-02-style-blind-review-metric-fallback.md"]
+```
+
+## Change
+
+- `punctuation_top` and `sensory_counts` now fall back to the reference-derived metrics only when the Profile has no numeric value for that dimension.
+- The fallback matches the existing behavior already used by rhythm and narrative density targets, so an `arcvellum/builtin-style-metrics/v1` qualitative preset does not force both dimensions to zero.
+- Explicit numeric Profile targets remain authoritative when present.
+
+## Verification
+
+- New regression test first failed with `punctuation = 0.0`, then passed after the fallback.
+- Targeted style loop tests passed.
+- Prompt registry validation, architecture audit, module-map check, and Studio doctor passed.

--- a/src/literary_engineering_studio_engine/literary/style/evaluator.py
+++ b/src/literary_engineering_studio_engine/literary/style/evaluator.py
@@ -106,9 +106,15 @@ def _score_style_match(
     candidate_text: str,
 ) -> dict[str, object]:
     rhythm = _rhythm_score(profile, reference, candidate)
-    punctuation = _counter_similarity_score(profile.get("punctuation_top", []), candidate.get("punctuation_top", []))
+    punctuation = _counter_similarity_score(
+        profile.get("punctuation_top") or reference.get("punctuation_top", []),
+        candidate.get("punctuation_top", []),
+    )
     lexical = _weighted_overlap_score(reference.get("top_bigrams", []), candidate.get("top_bigrams", []))
-    sensory = _dict_vector_score(profile.get("sensory_counts", {}), candidate.get("sensory_counts", {}))
+    sensory = _dict_vector_score(
+        profile.get("sensory_counts") or reference.get("sensory_counts", {}),
+        candidate.get("sensory_counts", {}),
+    )
     narrative = _density_score(profile, reference, candidate)
     structure = _structure_score(reference, candidate)
     originality = _originality_score(reference_text, candidate_text)

--- a/tests/test_style_evaluation_loop.py
+++ b/tests/test_style_evaluation_loop.py
@@ -12,6 +12,7 @@ from literary_engineering_studio_engine.literary.style.review import (
     prepare_style_semantic_review,
     style_review_machine_values,
 )
+from literary_engineering_studio_engine.literary.style.evaluator import StyleEvalOptions, evaluate_style
 
 
 def _quality_prompt() -> str:
@@ -186,6 +187,50 @@ class StyleEvaluationLoopTests(unittest.TestCase):
             stale = _style_engineering_state(root, profile)
             self.assertEqual(stale["current_step"], "style-review-task-file")
 
+
+class StyleEvaluatorMetricFallbackTests(unittest.TestCase):
+    def test_builtin_qualitative_profile_uses_reference_metric_targets(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            profile = root / "style" / "builtin"
+            profile.mkdir(parents=True)
+            (profile / "style_metrics.json").write_text(
+                json.dumps(
+                    {
+                        "schema": "arcvellum/builtin-style-metrics/v1",
+                        "preset_id": "clear-plain-zh",
+                    },
+                    ensure_ascii=False,
+                    indent=2,
+                ),
+                encoding="utf-8",
+            )
+            reference = root / "reference.txt"
+            reference.write_text(
+                "暗灯沿旧路移动。风声擦过墙角，河水带着冷意。灯光看不清门后的人影。\n",
+                encoding="utf-8",
+            )
+            candidate = root / "candidate.txt"
+            candidate.write_text(
+                "细灯贴着新街穿行。雨声绕过屋檐，石阶染上凉意。灯火照不到窗边的暗影。\n",
+                encoding="utf-8",
+            )
+            out_dir = profile / "evaluation_results" / "test"
+
+            result = evaluate_style(
+                StyleEvalOptions(
+                    profile_dir=profile,
+                    reference=reference,
+                    candidate=candidate,
+                    mode="blind-review",
+                    out_dir=out_dir,
+                )
+            )
+            payload = json.loads((out_dir / "style_eval_current.json").read_text(encoding="utf-8"))
+
+            self.assertEqual(result.overall_score, payload["overall_score"])
+            self.assertGreater(payload["scores"]["punctuation"]["score"], 0)
+            self.assertGreater(payload["scores"]["sensory_profile"]["score"], 0)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## 修改原因

`arcvellum/builtin-style-metrics/v1` 是定性风格预设，可能不包含 `punctuation_top` 或 `sensory_counts` 这类数值化指标。此前 `_score_style_match()` 会把空 Profile 目标直接传给余弦相似度计算，导致这两个维度即使候选文本标点规范、感官分布合理，也会被固定判为 0 分。

这不是候选文本质量问题，而是确定性评测器在缺少 Profile 数值目标时的 fallback 缺陷。已参照 rhythm / density 的既有行为：当 Profile 没有该维度数值时，使用 reference 派生指标作为目标；如果 Profile 明确提供了数值目标，则仍然优先使用 Profile。

## 变更

- `punctuation_top` 缺失时回退到 reference 的 `punctuation_top`。
- `sensory_counts` 缺失时回退到 reference 的 `sensory_counts`。
- 新增回归测试：定性 Profile 缺少数值字段时，punctuation 与 sensory_profile 分项必须大于 0。
- 新增修复说明文档。

## 验证

- `PYTHONPATH=src python -m unittest tests.test_style_evaluation_loop -v`
- `PYTHONPATH=src python -m literary_engineering_studio_engine prompt-registry-validate --json`
- `PYTHONPATH=src python scripts/architecture_audit.py`
- `PYTHONPATH=src python scripts/generate_module_map.py --check`

以上命令均通过。